### PR TITLE
typecast image object before sending to amazon s3 client

### DIFF
--- a/src/Outputs/Fly.php
+++ b/src/Outputs/Fly.php
@@ -24,6 +24,6 @@ class Fly implements OutputContract
      */
     public function save(Image $image, $path)
     {
-        return $this->flysystem->put($path, $image->encode());
+        return $this->flysystem->put($path, (string) $image->encode());
     }
 }


### PR DESCRIPTION
Fiz uma modificação para que o driver do Amazon S3 funcionasse corretamente.

De acordo com o driver do flysystem S3 o método put aceita somente string, sendo necessário fazer o typecast da imagem (examples http://image.intervention.io/api/encode) antes de submeter para o driver.

Dessa forma evitando o erro fstat() expects parameter 1 to be resource, object given

Refs:

http://sofd.developer-works.com/article/19271339/League+Flysystem+fstat()+expects+parameter+1+to+be+resource,+object+given

http://stackoverflow.com/questions/30738520/league-flysystem-fstat-expects-parameter-1-to-be-resource-object-given
