### PR TITLE
Updated to PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - hhvm
+  - 7.0
+  - 7.1
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,17 @@
     }
   },
   "require": {
+    "php": ">=7.0",
     "illuminate/support": "~5",
     "intervention/image": "~2.3",
     "graham-campbell/flysystem": "^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.*"
+    "phpunit/phpunit": "~6.0"
   },
   "autoload-dev": {
     "psr-4": {
-      "Vinicius73\\Attacher\\Tests\\": "tests/"
+      "Vinicius73\\Attacher\\Tests": "tests/"
     }
   },
   "extra": {

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -2,7 +2,6 @@
 
 namespace Vinicius73\Attacher\Tests;
 
-class ExampleTest extends \PHPUnit_Framework_TestCase
+class ExampleTest extends \PHPUnit\Framework\TestCase
 {
-
 }


### PR DESCRIPTION
Updated `phpunit/phpunit` to `~6.0`.

Dropped support to PHP `5.4`, `5.5`, `5.6`, and `HHVM` as PHPUnit 6.0 [requires PHP 7.0](https://github.com/sebastianbergmann/phpunit/blob/master/composer.json#L25).